### PR TITLE
(Incomplete) Add background thread to adjust canvas size dynamically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ RM = rm -f
 all: draw
 
 draw:
-	g++ $(SRCS) ./apps/draw.cpp -o draw -std=c++11
+	g++ $(SRCS) ./apps/draw.cpp -o draw -std=c++11 -pthread
 
 clean:
 	$(RM) draw


### PR DESCRIPTION
Adjusts the canvas size every 1/4 second, this may cause a slight delay when calling exit as that thread needs to complete it's function before joining the main thread, you can lower this.
So far it doesn't adjust the window in realtime, it does change the variables, however the canvas isn't redrawn on every change yet.